### PR TITLE
Use static inline for clang compatibility

### DIFF
--- a/e6809.c
+++ b/e6809.c
@@ -10,7 +10,7 @@
  *    the lower bits with the unused upper bits all set to zero.
  */
 
-#define einline __inline
+#define einline static __inline
 
 enum {
 	FLAG_E		= 0x80,

--- a/vecx.c
+++ b/vecx.c
@@ -4,7 +4,7 @@
 #include "osint.h"
 #include "e8910.h"
 
-#define einline __inline
+#define einline static __inline
 
 unsigned char rom[8192];
 unsigned char cart[32768];


### PR DESCRIPTION
The current code cannot be built with `clang` which is now the default compiler on OS X, complaining missing symbols for inline functions. It can be easily fixed by declaring them `static`. Here is a nice [explanation](http://stackoverflow.com/questions/16740515/simple-c-inline-linker-error).
